### PR TITLE
Support `dispose` on client wrapper

### DIFF
--- a/packages/monaco-editor-comp/src/wrapper.ts
+++ b/packages/monaco-editor-comp/src/wrapper.ts
@@ -170,6 +170,22 @@ export class MonacoEditorLanguageClientWrapper {
 
     }
 
+    async dispose(): Promise<void> {
+        if (this.editor) {
+            const model = this.editor.getModel();
+            model?.dispose();
+            this.editor.dispose();
+        }
+        if (this.diffEditor) {
+            const model = this.diffEditor.getModel();
+            model?.modified.dispose();
+            model?.original.dispose();
+            this.diffEditor.dispose();
+        }
+        await this.languageClient?.dispose();
+        this.worker?.terminate();
+    }
+
     swapEditors(container?: HTMLElement, dispatchEvent?: (event: Event) => boolean): void {
         if (this.editorConfig.useDiffEditor) {
             if (this.editor) {


### PR DESCRIPTION
When creating editors on the fly, I want to dispose the previous one before creating a new one. Since everything that should be disposed is private, this is currently quite difficult to do. The new method simply disposes everything.