### PR TITLE
startEditor, swapEditor and dispose now return promises

### DIFF
--- a/packages/monaco-editor-wrapper/index.html
+++ b/packages/monaco-editor-wrapper/index.html
@@ -33,7 +33,7 @@
 }`;
         let toggleDiff = true;
 
-        async function startEditor() {
+        function startEditor() {
             if (client.isStarted()) {
                 alert('Editor was already started!');
                 return;
@@ -65,7 +65,7 @@
             }, 10);
         };
 
-        async function swapEditors() {
+        function swapEditors() {
             const editorConfig = client.getEditorConfig();
             editorConfig.setUseDiffEditor(toggleDiff);
             editorConfig.setMainLanguageId(languageId);

--- a/packages/monaco-editor-wrapper/index.html
+++ b/packages/monaco-editor-wrapper/index.html
@@ -33,7 +33,7 @@
 }`;
         let toggleDiff = true;
 
-        function startEditor() {
+        async function startEditor() {
             if (client.isStarted()) {
                 alert('Editor was already started!');
                 return;
@@ -53,10 +53,19 @@
                 wsPath: "sampleServer"
             });
 
-            client.startEditor(document.getElementById("monaco-editor-root"));
+            client.startEditor(document.getElementById("monaco-editor-root"))
+                .then(s => console.log(s))
+                .catch(e => console.error(e));
+
+            // provoke a too early dispose
+            setTimeout(() => {
+                client.dispose()
+                    .then(s => console.log(s))
+                    .catch(e => console.error(e));
+            }, 10);
         };
 
-        function swapEditors() {
+        async function swapEditors() {
             const editorConfig = client.getEditorConfig();
             editorConfig.setUseDiffEditor(toggleDiff);
             editorConfig.setMainLanguageId(languageId);
@@ -64,8 +73,12 @@
             editorConfig.setDiffLanguageId(languageId)
             editorConfig.setDiffCode(codeDiff);
 
-            client.swapEditors(document.getElementById("monaco-editor-root"));
-            toggleDiff = !toggleDiff;
+            client.swapEditors(document.getElementById("monaco-editor-root"))
+                .then(s => {
+                    toggleDiff = !toggleDiff;
+                    console.log(s)
+                })
+                .catch(e => console.error(e));
         }
 
         async function disposeEditor() {
@@ -74,7 +87,7 @@
             console.log(`LanguageClient ${client.languageClient}`);
             console.log(`Worker ${client.worker}`);
 
-            await client.dispose(true)
+            await client.dispose()
                 .then(() => {
                     console.log(`Editor ${client.editor}`);
                     console.log(`DiffEditor ${client.diffEditor}`);

--- a/packages/monaco-editor-wrapper/src/index.ts
+++ b/packages/monaco-editor-wrapper/src/index.ts
@@ -280,7 +280,7 @@ export class MonacoEditorLanguageClientWrapper {
         }
     }
 
-    private async disposeLanguageClient() {
+    private async disposeLanguageClient(): Promise<string> {
         if (this.languageClient && this.languageClient.isRunning()) {
             this.disposeEditor();
             this.disposeDiffEditor();
@@ -293,7 +293,7 @@ export class MonacoEditorLanguageClientWrapper {
                     return 'monaco-languageclient and monaco-editor were successfully disposed';
                 })
                 .catch((e: Error) => {
-                    throw new Error(`Disposing the monaco-languageclient resulted in error: ${e}`);
+                    return `Disposing the monaco-languageclient resulted in error: ${e}`;
                 });
         }
         else {

--- a/packages/monaco-editor-wrapper/src/index.ts
+++ b/packages/monaco-editor-wrapper/src/index.ts
@@ -426,7 +426,7 @@ export class MonacoEditorLanguageClientWrapper {
                     const socket = toSocket(webSocket);
                     const reader = new WebSocketMessageReader(socket);
                     const writer = new WebSocketMessageWriter(socket);
-                    this.handleLanguageClienStart(reader, writer, resolve, reject);
+                    this.handleLanguageClientStart(reader, writer, resolve, reject);
                 };
             } else {
                 const workerConfigOptions = lcConfigOptions as WorkerConfigOptions;
@@ -438,12 +438,12 @@ export class MonacoEditorLanguageClientWrapper {
                 }
                 reader = new BrowserMessageReader(this.worker);
                 writer = new BrowserMessageWriter(this.worker);
-                this.handleLanguageClienStart(reader, writer, resolve, reject);
+                this.handleLanguageClientStart(reader, writer, resolve, reject);
             }
         });
     }
 
-    private async handleLanguageClienStart(reader: WebSocketMessageReader | BrowserMessageReader,
+    private async handleLanguageClientStart(reader: WebSocketMessageReader | BrowserMessageReader,
         writer: WebSocketMessageWriter | BrowserMessageWriter,
         resolve: (value: string) => void, reject: (reason?: unknown) => void) {
 


### PR DESCRIPTION
Async start and dispose code is now properly handled

Hint: The little "test" index.html tries to dispose after 10 ms when started which does not work (as expected now). We need real tests here at some point, I think
