### PR TITLE
Add language client initialization options

### DIFF
--- a/packages/monaco-editor-wrapper/src/codeEditorConfig.ts
+++ b/packages/monaco-editor-wrapper/src/codeEditorConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 export type WebSocketConfigOptions = {
@@ -31,6 +30,7 @@ export class CodeEditorConfig {
 
     // languageclient related configuration
     private useLanguageClient = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private initializationOptions: any = undefined;
     // create config type web socket / web worker
     private useWebSocket = true;
@@ -132,10 +132,12 @@ export class CodeEditorConfig {
         this.lcConfigOptions = lcConfigOptions;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getInitializationOptions(): any {
         return this.initializationOptions;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setInitializationOptions(options: any): void {
         this.initializationOptions = options;
     }

--- a/packages/monaco-editor-wrapper/src/codeEditorConfig.ts
+++ b/packages/monaco-editor-wrapper/src/codeEditorConfig.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 export type WebSocketConfigOptions = {
@@ -30,6 +31,7 @@ export class CodeEditorConfig {
 
     // languageclient related configuration
     private useLanguageClient = false;
+    private initializationOptions: any = undefined;
     // create config type web socket / web worker
     private useWebSocket = true;
     private lcConfigOptions = this.useWebSocket ? this.getDefaultWebSocketConfig() : this.getDefaultWorkerConfig();
@@ -128,6 +130,14 @@ export class CodeEditorConfig {
 
     setLanguageClientConfigOptions(lcConfigOptions: WebSocketConfigOptions | WorkerConfigOptions): void {
         this.lcConfigOptions = lcConfigOptions;
+    }
+
+    getInitializationOptions(): any {
+        return this.initializationOptions;
+    }
+
+    setInitializationOptions(options: any): void {
+        this.initializationOptions = options;
     }
 
     getDefaultWebSocketConfig(): WebSocketConfigOptions {

--- a/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
+++ b/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
@@ -344,7 +344,9 @@ export class MonacoEditorLanguageClientWrapper {
                 errorHandler: {
                     error: () => ({ action: ErrorAction.Continue }),
                     closed: () => ({ action: CloseAction.DoNotRestart })
-                }
+                },
+                // allow to initialize the language client with user specific options
+                initializationOptions: this.editorConfig.getInitializationOptions()
             },
             // create a language client connection from the JSON RPC connection on demand
             connectionProvider: {


### PR DESCRIPTION
Some language servers need to receive some additional initialization options/information during their startup. For example, the [langium-sql](https://github.com/langium/langium-sql) project will need this once we move to the web to load a DB schema during its initialization.