### PR TITLE
Enable to update/restart the language client

### DIFF
--- a/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
+++ b/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
@@ -156,7 +156,7 @@ export class MonacoEditorLanguageClientWrapper {
         }
     }
 
-    async restart(): Promise<string> {
+    async restartLanguageClient(): Promise<string> {
         await this.disposeLanguageClient();
         if (!this.useVscodeConfig) {
             this.monacoConfig.updateMonacoConfig(this.editorConfig.getMainLanguageId(), this.editorConfig.getTheme());

--- a/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
+++ b/packages/monaco-editor-wrapper/src/monacoEditorLanguageClientWrapper.ts
@@ -156,6 +156,14 @@ export class MonacoEditorLanguageClientWrapper {
         }
     }
 
+    async restart(): Promise<string> {
+        await this.disposeLanguageClient();
+        if (!this.useVscodeConfig) {
+            this.monacoConfig.updateMonacoConfig(this.editorConfig.getMainLanguageId(), this.editorConfig.getTheme());
+        }
+        return this.startLanguageClientConnection(this.editorConfig.getLanguageClientConfigOptions());
+    }
+
     private disposeEditor() {
         if (this.editor) {
             const model = this.editor.getModel();


### PR DESCRIPTION
Right now, changing the language client configuration requires to dispose the monaco editor that contains the language client. This change allows to just restart the language client with the new configuration.