### PR TITLE
README Corrections & Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Monaco Editor Wrapper and Monaco Editor React Component
 
-This repository started as Lit component for Monaco Editor, but it transformed into a wrapper for `monaco-editor`, `monaco-languageclient` and `monaco-vscode-api` and now features a react component (`@typefox/monaco-editor-react`) that encapsulates the `monaco-editor-wrapper`
+This repository started as a Lit component for Monaco Editor, but it has transformed into a wrapper for `monaco-editor`, `monaco-languageclient` and `monaco-vscode-api` and now features a react component (`@typefox/monaco-editor-react`) that encapsulates the `monaco-editor-wrapper`.
 
 ## Packages
 
 There are three npm packages generated from this repository:
 
 - [Monaco Editor Wrapper](./packages/monaco-editor-wrapper/) + Language Client: Wrapped [monaco-editor](https://github.com/microsoft/monaco-editor) with the capability to plug-in [monaco-languageclient](https://github.com/TypeFox/monaco-languageclient) to connect to languages servers locally running (web worker) or remotely running (web socket).
-- [Monaco Editor React Component](./packages/monaco-editor-react/) Monaco Editor React Component enclosing the **Monaco Editor Wrapper**
-- [Monaco Editor Workers](./packages/monaco-editor-workers/) Bundles the editor and language workers of monaco as module and classic worker. It supplies a function that eases loading them in an application context.
+- [Monaco Editor React Component](./packages/monaco-editor-react/): Monaco Editor React Component enclosing the **Monaco Editor Wrapper**
+- [Monaco Editor Workers](./packages/monaco-editor-workers/): Bundles the editor and language workers of monaco as module and classic worker. It supplies a function that eases loading them in an application context.
 
-Additionally you find a private [examples packages](./packages/examples/) containing all examples that is served by vite (see next chapter).
+Additionally you can find a private [examples packages](./packages/examples/) containing all examples that are served by Vite (see next chapter).
 
 ## Getting Started
+
+We recommend using [Volta](https://volta.sh/) to ensure your node & npm are on known good versions.
 
 If you have node.js LTS available, then from the root of the project run:
 
@@ -21,7 +23,9 @@ npm i
 npm run build
 ```
 
-Aftwerwards, launch the Vite development server:
+If you get an error with `npm i` regarding tree-mending, you can run `npm ci` to clean things up from previous installations and continue.
+
+Afterwards, launch the Vite development server:
 
 ```bash
 npm run dev
@@ -33,4 +37,4 @@ If you want to change dependent code in the examples, you have to watch code cha
 npm run watch
 ```
 
-You find examples (manual human testing) here [index.html](./index.html). They can be used once Vite is running. You can reach it once started on <http://localhost:20001>.
+You can find examples (manual human testing) here [index.html](./index.html). They can be used once Vite is running. You can reach it once started on <http://localhost:20001>.

--- a/packages/monaco-editor-react/README.md
+++ b/packages/monaco-editor-react/README.md
@@ -1,10 +1,12 @@
 # React component for Monaco-Editor and Monaco Languageclient
 
-This packages provides a React component that it based on [monaco-editor-wrapper](../monaco-editor-wrapper/). It behaves in nearly the same way as the monaco editor, with the primary difference being that you interact with it through a React component.
+This packages provides a React component that it based on the [monaco-editor-wrapper](../monaco-editor-wrapper/). It behaves in nearly the same way as the monaco editor, with the primary difference being that you interact with it through a React component.
 
-The [monaco-languageclient](https://github.com/TypeFox/monaco-languageclient) can be activated to connect to a language server either via jsonrpc over a websocket to an exernal server process or via language server protocol for browser where the language server runs in a web worker.
+The [monaco-languageclient](https://github.com/TypeFox/monaco-languageclient) can be activated to connect to a language server either via jsonrpc over a websocket to an exernal server process, or via the Language Server Protocol for the browser where the language server runs in a web worker.
 
 ## Getting Started
+
+We recommend using [Volta](https://volta.sh/) to ensure your node & npm are on known good versions.
 
 If you have node.js LTS available, then from the root of the project run:
 
@@ -13,23 +15,11 @@ npm i
 npm run build
 ```
 
-Aftwerwards, launch the Vite development server:
-
-```bash
-npm run dev
-```
-
-If you want to change dependent code in the examples, you have to watch code changes in parallel:
-
-```bash
-npm run watch
-```
-
-You find examples (manual human testing) here [index.html](./index.html). Vite serves them here: <http://localhost:20001>
+This will clean, compile and build a bundle of the monaco-editor-react component, which you can reference in your own projects.
 
 ## Usage
 
-You can import the monaco react component for easy use in an existing React project. Below you can see a quick example of a fully functional implementation for some TypeScript. The react component uses the same `UserConfig` approach which is then applied to `monaco-editor-wrapper`.
+You can import the monaco react component for easy use in an existing React project. Below you can see a quick example of a fully functional implementation in TypeScript. The react component uses the same `UserConfig` approach which is then applied to `monaco-editor-wrapper`.
 
 ```typescript
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
@@ -67,7 +57,7 @@ const comp = <MonacoEditorReactComp
 
 ### Bundled Usage
 
-For special cases where you might want the component to be processed in advance, so we also provide a pre-bundled version that you can reference instead. This can be helpful if you're working within some other framework besides React (Hugo for example).
+For special cases you might want the component to be processed in advance. For these cases we provide a pre-bundled version that you can reference instead, built using `npm run build:bundle`. This can be helpful if you're working within some other framework besides React (Hugo for example).
 
 ```ts
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react/bundle';
@@ -75,7 +65,7 @@ import { MonacoEditorReactComp } from '@typefox/monaco-editor-react/bundle';
 
 ## Examples
 
-These are the exmples specifically for `@typefox/monaco-editor-react` you find in the repository:
+These are the examples specifically for `@typefox/monaco-editor-react` that you can find in the repository:
 
 - TypeScript editor worker using classical configuration [see](./packages/examples/react_ts.html)
 - Langium statemachine web worker using the exact same user configuration as [wrapper example](./packages/examples/wrapper_langium.html), [see](./packages/examples/react_langium.html)
@@ -104,11 +94,11 @@ class MyComponent extends React.Component {
 }
 ```
 
-You can then access the `current` property of the ref to get a refernce to your component. This can then be used to invoke the executeCommands function present in the component.
+You can then access the `current` property of the ref to get a reference to your component. This can then be used to invoke the `executeCommands` function present in the component.
 
 ```ts
 this.myRef.current.executeCommand('myCustomCommand', args...);
 ```
 
-This will return an instance of `Thenable`, which should contain the returned data of executing your custom command. As you can imagine, this is incredibly helpful for getting internal access for specific language handilng, but without needing details about the internals of your language server to do it.
+This will return an instance of `Thenable`, which should contain the returned data of executing your custom command. As you can imagine, this is incredibly helpful for getting internal access for specific language handling, but without needing details about the internals of your language server to do it.
 

--- a/packages/monaco-editor-wrapper/README.md
+++ b/packages/monaco-editor-wrapper/README.md
@@ -4,6 +4,8 @@ This packages provides a wrapped `monaco-editor` with or without language suppor
 
 ## Getting Started
 
+We recommend using [Volta](https://volta.sh/) to ensure your node & npm are on known good versions.
+
 If you have node.js LTS available, then from the root of the project run:
 
 ```bash
@@ -11,23 +13,13 @@ npm i
 npm run build
 ```
 
-Aftwerwards, launch the Vite development server:
-
-```bash
-npm run dev
-```
-
-If you want to change dependent code in the examples, you have to watch code changes in parallel:
-
-```bash
-npm run watch
-```
-
-You find examples (manual human testing) here [index.html](./index.html). Vite serves them here: <http://localhost:20001>
+This will clean, compile and build a bundle of the `monaco-editor-wrapper`, which you can reference in your own projects. For examples, you can see the top-level [README](../../README.md#getting-started) with details on running a local dev instance.
 
 ## Configuration
 
-With release 2.0.0 the configuration approach is completely revised. The `UserConfig` now contains everything and is passed to the `start` function of the wrapper. Because [monaco-vscode-api](https://github.com/CodinGame/monaco-vscode-api) uses a VS Code extension like configuration approach, the `UserConfig` allows to configure monaco-editor the [classical way](./src/editorClassic.ts) or to use [monaco-vscode-api way](./src/editorVscodeApi.ts). Additinonally, [monaco-vscode-api](https://github.com/CodinGame/monaco-vscode-api) brings VS Code services to monaco-editor it usually does not have (Textmate Support, VS Code Theme Support, Keybindings, etc.).
+With release 2.0.0, the configuration approach is completely revised.
+
+The `UserConfig` now contains everything and is passed to the `start` function of the wrapper. Because [monaco-vscode-api](https://github.com/CodinGame/monaco-vscode-api) uses a VS Code extension like configuration approach, the `UserConfig` allows to configure monaco-editor the [classical way](./src/editorClassic.ts) or to use [monaco-vscode-api way](./src/editorVscodeApi.ts). Additionally, [monaco-vscode-api](https://github.com/CodinGame/monaco-vscode-api) brings VS Code services to monaco-editor it usually does not have (Textmate Support, VS Code Theme Support, Keybindings, etc.).
 
 ## Usage
 
@@ -72,7 +64,7 @@ const run = async () => {
 
 ## Examples
 
-These are the exmples specifically for `monaco-editor-wrapper` you find in the repository:
+These are the examples specifically for `monaco-editor-wrapper` you find in the repository:
 
 - TypeScript editor worker using classical configuration, [see](./packages/examples/wrapper_ts.html)
 - Language client & web socket language server example using monaco-vscode-api configuration [see](./packages/examples/wrapper_ws.html) It requires the server available [here](https://github.com/TypeFox/monaco-languageclient/tree/main#examples)


### PR DESCRIPTION
With the upcoming 2.0.0 release coming up I went through some of the README details on the various projects, and found some suggestions and corrections that I wanted to bring up. In some cases there were also references to running non-existent `npm run dev` scripts, which seem to be only connected to the top-level of the project.

Feel free to add additional commits on top of this for further clarification or revision.