### PR TITLE
Make worker handling more flexible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3232,12 +3232,12 @@
     "packages/examples": {
       "name": "monaco-editor-wrapper-examples",
       "dependencies": {
-        "@typefox/monaco-editor-react": "~1.0.1",
+        "@typefox/monaco-editor-react": "1.0.2-next.0",
         "http-server": "~14.1.1",
         "langium": "~1.2.0",
         "langium-statemachine-dsl": "~1.2.0",
         "monaco-editor-workers": "~0.39.1",
-        "monaco-editor-wrapper": "~2.0.1",
+        "monaco-editor-wrapper": "2.0.2-next.0",
         "react": "~18.2.0",
         "react-dom": "~18.2.0",
         "request-light": "~0.7.0",
@@ -3317,14 +3317,14 @@
     },
     "packages/monaco-editor-react": {
       "name": "@typefox/monaco-editor-react",
-      "version": "1.0.1",
+      "version": "1.0.2-next.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~18.2.8",
         "@types/react-dom": "~18.2.4"
       },
       "peerDependencies": {
-        "monaco-editor-wrapper": "~2.0.1",
+        "monaco-editor-wrapper": "2.0.2-next.0",
         "react": "~18.2.0",
         "react-dom": "~18.2.0"
       }
@@ -3345,7 +3345,7 @@
       "integrity": "sha512-zhbZ2Nx93tLR8aJmL2zI1mhJpsl87HMebNBM6R8z4pLfs8pj604pIVIVwyF1TivcfNtIPpMXL+nb3DsBmE/x6Q=="
     },
     "packages/monaco-editor-wrapper": {
-      "version": "2.0.1",
+      "version": "2.0.2-next.0",
       "license": "MIT",
       "dependencies": {
         "monaco-languageclient": "~6.1.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@typefox/monaco-editor-react": "~1.0.1",
+    "@typefox/monaco-editor-react": "1.0.2-next.0",
     "http-server": "~14.1.1",
     "langium": "~1.2.0",
     "langium-statemachine-dsl": "~1.2.0",
-    "monaco-editor-wrapper": "~2.0.1",
+    "monaco-editor-wrapper": "2.0.2-next.0",
     "monaco-editor-workers": "~0.39.1",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",

--- a/packages/examples/src/langium/langiumWrapperConfig.ts
+++ b/packages/examples/src/langium/langiumWrapperConfig.ts
@@ -15,6 +15,11 @@ export const createLangiumGlobalConfig = async (htmlElement: HTMLElement): Promi
     const workerUrl = new URL('./dist/worker/statemachineServerWorker.js', window.location.href);
     console.log(`Langium worker URL: ${workerUrl}`);
 
+    const worker = new Worker(workerUrl, {
+        type: 'module',
+        name: 'Statemachine LS',
+    });
+
     return {
         htmlElement: htmlElement,
         wrapperConfig: {
@@ -73,7 +78,7 @@ export const createLangiumGlobalConfig = async (htmlElement: HTMLElement): Promi
                 extensionFilesOrContents: extensionFilesOrContents,
                 userConfiguration: {
                     json: `{
-    "workbench.colorTheme": "Default Dark+ Experimental",
+    "workbench.colorTheme": "Default Dark Modern",
     "editor.fontSize": 14,
     "editor.lightbulb.enabled": true,
     "editor.lineHeight": 20,
@@ -93,11 +98,7 @@ export const createLangiumGlobalConfig = async (htmlElement: HTMLElement): Promi
         languageClientConfig: {
             enabled: true,
             useWebSocket: false,
-            workerConfigOptions: {
-                url: workerUrl,
-                type: 'module',
-                name: 'Statemachine LS',
-            }
+            workerConfigOptions: worker
         }
     };
 };

--- a/packages/monaco-editor-react/CHANGELOG.md
+++ b/packages/monaco-editor-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to npm module [@typefox/monaco-editor-react](https://www.npmjs.com/package/monaco-editor-react) are documented in this file.
 
+## [1.0.2] - 2023-06-14
+
+- Make worker handling more flexible [#27](https://github.com/TypeFox/monaco-components/pull/27)
+
 ## [1.0.1] - 2023-06-12
 
 - Updated to `monaco-editor-wrapper` `2.0.1` using `monaco-languageclient` `6.1.0` / `monaco-vscode-api` `1.79.1` and `monaco-editor` `0.38.0`

--- a/packages/monaco-editor-react/package.json
+++ b/packages/monaco-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typefox/monaco-editor-react",
-  "version": "1.0.1",
+  "version": "1.0.2-next.0",
   "license": "MIT",
   "description": "React component for Monaco-Editor and Monaco Languageclient",
   "keywords": [
@@ -50,7 +50,7 @@
     "npm": "9.6.6"
   },
   "peerDependencies": {
-    "monaco-editor-wrapper": "~2.0.1",
+    "monaco-editor-wrapper": "2.0.2-next.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/packages/monaco-editor-wrapper/CHANGELOG.md
+++ b/packages/monaco-editor-wrapper/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to npm module [monaco-editor-wrapper](https://www.npmjs.com/package/monaco-editor-wrapper) are documented in this file.
 
+## [2.0.2] - 2023-06-14
+
+- Make worker handling more flexible [#27](https://github.com/TypeFox/monaco-components/pull/27)
+
 ## [2.0.1] - 2023-06-12
 
 - Updated to `monaco-languageclient` `6.1.0` using `monaco-vscode-api` `1.79.1` and `monaco-editor` `0.38.0`

--- a/packages/monaco-editor-wrapper/package.json
+++ b/packages/monaco-editor-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-editor-wrapper",
-  "version": "2.0.1",
+  "version": "2.0.2-next.0",
   "license": "MIT",
   "description": "Monaco-Editor and Monaco Languageclient Wrapper",
   "keywords": [


### PR DESCRIPTION
Allow to configure a worker directly and to influence the behaviour on languageclient restart:

- Instead of parsing only a worker configuration, you can now pass it. `createLangiumGlobalConfig` makes use of this for testing
- On `restartLanguageClient` you can now select to not dispose a worker a provide a new one for the restart.
- The react component required some more code to check that the previous and current config machtes

Btw, there are some formatting changes that have nothing to do with this change.
