### PR TITLE
allow to pass a uri via editor config and model update

### DIFF
--- a/packages/examples/src/common.ts
+++ b/packages/examples/src/common.ts
@@ -19,7 +19,7 @@ export const updateModel = async (modelUpdate: ModelUpdate) => {
     } else {
         await wrapper?.updateModel(modelUpdate);
     }
-}
+};
 
 export const swapEditors = async (userConfig: UserConfig, code: string, codeOriginal?: string) => {
     userConfig.editorConfig.useDiffEditor = !userConfig.editorConfig.useDiffEditor;

--- a/packages/examples/src/common.ts
+++ b/packages/examples/src/common.ts
@@ -1,4 +1,4 @@
-import { MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
+import { ModelUpdate, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
 import { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 export const wrapper = new MonacoEditorLanguageClientWrapper();
@@ -12,6 +12,14 @@ export const startEditor = async (userConfig: UserConfig, code: string, codeOrig
     toggleSwapDiffButton(true);
     await restartEditor(userConfig);
 };
+
+export const updateModel = async (modelUpdate: ModelUpdate) => {
+    if (wrapper.getMonacoEditorWrapper()?.getEditorConfig().useDiffEditor) {
+        await wrapper?.updateDiffModel(modelUpdate);
+    } else {
+        await wrapper?.updateModel(modelUpdate);
+    }
+}
 
 export const swapEditors = async (userConfig: UserConfig, code: string, codeOriginal?: string) => {
     userConfig.editorConfig.useDiffEditor = !userConfig.editorConfig.useDiffEditor;

--- a/packages/examples/src/common.ts
+++ b/packages/examples/src/common.ts
@@ -3,20 +3,20 @@ import { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 export const wrapper = new MonacoEditorLanguageClientWrapper();
 
-export const startEditor = async (userConfig: UserConfig, codeMain: string, codeOrg?: string) => {
+export const startEditor = async (userConfig: UserConfig, code: string, codeOriginal?: string) => {
     if (wrapper.isStarted()) {
         alert('Editor was already started!');
         return;
     }
-    configureCodeEditors(userConfig, codeMain, codeOrg);
+    configureCodeEditors(userConfig, code, codeOriginal);
     toggleSwapDiffButton(true);
     await restartEditor(userConfig);
 };
 
-export const swapEditors = async (userConfig: UserConfig, codeMain: string, codeOrg?: string) => {
+export const swapEditors = async (userConfig: UserConfig, code: string, codeOriginal?: string) => {
     userConfig.editorConfig.useDiffEditor = !userConfig.editorConfig.useDiffEditor;
     saveMainCode(!userConfig.editorConfig.useDiffEditor);
-    configureCodeEditors(userConfig, codeMain, codeOrg);
+    configureCodeEditors(userConfig, code, codeOriginal);
     await restartEditor(userConfig);
 };
 
@@ -35,12 +35,12 @@ const restartEditor = async (userConfig: UserConfig) => {
     logEditorInfo(userConfig);
 };
 
-const configureCodeEditors = (userConfig: UserConfig, codeMain: string, codeOrg?: string) => {
+const configureCodeEditors = (userConfig: UserConfig, code: string, codeOriginal?: string) => {
     if (userConfig.editorConfig.useDiffEditor) {
-        userConfig.editorConfig.code = codeMain;
-        userConfig.editorConfig.codeOriginal = codeOrg;
+        userConfig.editorConfig.code = code;
+        userConfig.editorConfig.codeOriginal = codeOriginal;
     } else {
-        userConfig.editorConfig.code = codeMain;
+        userConfig.editorConfig.code = code;
     }
 };
 

--- a/packages/examples/src/wrapperTs.ts
+++ b/packages/examples/src/wrapperTs.ts
@@ -77,7 +77,11 @@ try {
         }
     });
     document.querySelector('#button-dispose')?.addEventListener('click', async () => {
-        codeOriginal = await disposeEditor(userConfig);
+        if (wrapper.getMonacoEditorWrapper()?.getEditorConfig().uri === codeUri) {
+            code = await disposeEditor(userConfig);
+        }else {
+            codeOriginal = await disposeEditor(userConfig);
+        }
     });
 
     startEditor(userConfig, code, codeOriginal);

--- a/packages/examples/src/wrapperTs.ts
+++ b/packages/examples/src/wrapperTs.ts
@@ -1,15 +1,19 @@
-import { disposeEditor, startEditor, swapEditors } from './common.js';
+import { disposeEditor, startEditor, swapEditors, wrapper } from './common.js';
 
 import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
 import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
 
 import { buildWorkerDefinition } from 'monaco-editor-workers';
+import { UserConfig } from 'monaco-editor-wrapper';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers', import.meta.url, false);
 
-const codeOrg = `function sayHello(): string {
+const codeUri = "/tmp/hello.ts";
+let code = `function sayHello(): string {
     return "Hello";
 };`;
-let codeMain = `function sayGoodbye(): string {
+
+const codeOriginalUri = "/tmp/goodbye.ts";
+let codeOriginal = `function sayGoodbye(): string {
     return "Goodbye";
 };`;
 
@@ -23,7 +27,7 @@ const monacoEditorConfig = {
     }
 };
 
-const userConfig = {
+const userConfig: UserConfig = {
     htmlElement: document.getElementById('monaco-editor-root') as HTMLElement,
     wrapperConfig: {
         useVscodeConfig: false,
@@ -39,9 +43,10 @@ const userConfig = {
     },
     editorConfig: {
         languageId: 'typescript',
-        code: codeOrg,
+        code: code,
+        uri: codeUri,
+        codeOriginal: codeOriginal,
         useDiffEditor: false,
-        codeOriginal: codeMain,
         editorOptions: monacoEditorConfig,
         diffEditorOptions: monacoEditorConfig,
         theme: 'vs-dark',
@@ -51,16 +56,31 @@ const userConfig = {
 
 try {
     document.querySelector('#button-start')?.addEventListener('click', () => {
-        startEditor(userConfig, codeMain, codeOrg);
+        startEditor(userConfig, code, codeOriginal);
     });
     document.querySelector('#button-swap')?.addEventListener('click', () => {
-        swapEditors(userConfig, codeMain, codeOrg);
+        swapEditors(userConfig, code, codeOriginal);
+    });
+    document.querySelector('#button-swap-code')?.addEventListener('click', () => {
+        if (wrapper.getMonacoEditorWrapper()?.getEditorConfig().uri === codeUri) {
+            wrapper.updateModel({
+                code: codeOriginal,
+                uri: codeOriginalUri,
+                languageId: "typescript",
+            });
+        }else {
+            wrapper.updateModel({
+                code: code,
+                uri: codeUri,
+                languageId: "typescript",
+            });
+        }
     });
     document.querySelector('#button-dispose')?.addEventListener('click', async () => {
-        codeMain = await disposeEditor(userConfig);
+        codeOriginal = await disposeEditor(userConfig);
     });
 
-    startEditor(userConfig, codeMain, codeOrg);
+    startEditor(userConfig, code, codeOriginal);
 } catch (e) {
     console.error(e);
 }

--- a/packages/examples/src/wrapperTs.ts
+++ b/packages/examples/src/wrapperTs.ts
@@ -1,4 +1,4 @@
-import { disposeEditor, startEditor, swapEditors, wrapper } from './common.js';
+import { disposeEditor, startEditor, swapEditors, updateModel, wrapper } from './common.js';
 
 import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
 import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
@@ -7,12 +7,12 @@ import { buildWorkerDefinition } from 'monaco-editor-workers';
 import { UserConfig } from 'monaco-editor-wrapper';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers', import.meta.url, false);
 
-const codeUri = "/tmp/hello.ts";
+const codeUri = '/tmp/hello.ts';
 let code = `function sayHello(): string {
     return "Hello";
 };`;
 
-const codeOriginalUri = "/tmp/goodbye.ts";
+const codeOriginalUri = '/tmp/goodbye.ts';
 let codeOriginal = `function sayGoodbye(): string {
     return "Goodbye";
 };`;
@@ -63,16 +63,16 @@ try {
     });
     document.querySelector('#button-swap-code')?.addEventListener('click', () => {
         if (wrapper.getMonacoEditorWrapper()?.getEditorConfig().uri === codeUri) {
-            wrapper.updateModel({
+            updateModel({
                 code: codeOriginal,
                 uri: codeOriginalUri,
-                languageId: "typescript",
+                languageId: 'typescript',
             });
         }else {
-            wrapper.updateModel({
+            updateModel({
                 code: code,
                 uri: codeUri,
-                languageId: "typescript",
+                languageId: 'typescript',
             });
         }
     });

--- a/packages/examples/wrapper_ts.html
+++ b/packages/examples/wrapper_ts.html
@@ -9,6 +9,7 @@
 
 <body>
     <button type="button" id="button-start">Start</button>
+    <button type="button" id="button-swap-code">Swap Code</button>
     <button type="button" id="button-swap">Swap Diff</button>
     <button type="button" id="button-dispose">Dispose</button>
     <div id="monaco-editor-root" style="height: 80vh;"></div>

--- a/packages/monaco-editor-wrapper/src/editor.ts
+++ b/packages/monaco-editor-wrapper/src/editor.ts
@@ -4,7 +4,7 @@ import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShow
 import { editor, Uri } from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { createConfiguredEditor, createConfiguredDiffEditor, createModelReference, ITextFileEditorModel } from 'vscode/monaco';
 import { IReference } from 'vscode/service-override/editor';
-import { EditorConfig, UserConfig } from './wrapper.js';
+import { EditorConfig, ModelUpdate, UserConfig } from './wrapper.js';
 import { EditorVscodeApiConfig } from './editorVscodeApi.js';
 import { EditorClassicConfig } from './editorClassic.js';
 
@@ -101,19 +101,23 @@ export class MonacoEditorBase {
         }
     }
 
-    async updateModel(modelUpdate: {
-        languageId: string;
-        code: string;
-        uri?: string;
-    }): Promise<void> {
+    async updateModel(modelUpdate: ModelUpdate): Promise<void> {
         if (!this.editor) {
             return Promise.reject(new Error('You cannot update the editor model, because the regular editor is not configured.'));
         }
-        this.editorConfig.languageId = modelUpdate.languageId;
-        this.editorConfig.code = modelUpdate.code;
-        if (modelUpdate.uri) {
+
+        if (modelUpdate.code != undefined) {
+            this.editorConfig.code = modelUpdate.code;
+        }
+
+        if (modelUpdate.languageId != undefined) {
+            this.editorConfig.languageId = modelUpdate.languageId;
+        }
+
+        if (modelUpdate.uri != undefined) {
             this.editorConfig.uri = modelUpdate.uri;
         }
+
         await this.updateEditorModel(true);
     }
 

--- a/packages/monaco-editor-wrapper/src/editor.ts
+++ b/packages/monaco-editor-wrapper/src/editor.ts
@@ -132,7 +132,7 @@ export class MonacoEditorBase {
     private async updateEditorModel(updateEditor: boolean): Promise<void> {
         this.modelRef?.dispose();
 
-        let uri: Uri = this.getEditorUri('code');
+        const uri: Uri = this.getEditorUri('code');
         this.modelRef = await createModelReference(uri, this.editorConfig.code) as unknown as IReference<ITextFileEditorModel>;
         this.modelRef.object.setLanguageId(this.editorConfig.languageId);
         this.editorOptions!.model = this.modelRef.object.textEditorModel;
@@ -173,8 +173,8 @@ export class MonacoEditorBase {
         this.modelRef?.dispose();
         this.modelOriginalRef?.dispose();
 
-        let uri: Uri = this.getEditorUri('code');
-        let uriOriginal: Uri = this.getEditorUri('codeOriginal');
+        const uri: Uri = this.getEditorUri('code');
+        const uriOriginal: Uri = this.getEditorUri('codeOriginal');
 
         const promises = [];
         promises.push(createModelReference(uri, this.editorConfig.code));

--- a/packages/monaco-editor-wrapper/src/editor.ts
+++ b/packages/monaco-editor-wrapper/src/editor.ts
@@ -106,26 +106,7 @@ export class MonacoEditorBase {
             return Promise.reject(new Error('You cannot update the editor model, because the regular editor is not configured.'));
         }
 
-        if (modelUpdate.code !== undefined) {
-            this.editorConfig.code = modelUpdate.code;
-        }
-
-        if (modelUpdate.languageId !== undefined) {
-            this.editorConfig.languageId = modelUpdate.languageId;
-        }
-
-        if (modelUpdate.uri !== undefined) {
-            this.editorConfig.uri = modelUpdate.uri;
-        }
-
-        if (modelUpdate.codeOriginal !== undefined) {
-            this.editorConfig.codeOriginal = modelUpdate.codeOriginal;
-        }
-
-        if (modelUpdate.codeOriginalUri !== undefined) {
-            this.editorConfig.codeOriginalUri = modelUpdate.codeOriginalUri;
-        }
-
+        this.updateEditorConfig(modelUpdate);
         await this.updateEditorModel(true);
     }
 
@@ -146,26 +127,7 @@ export class MonacoEditorBase {
             return Promise.reject(new Error('You cannot update the diff editor models, because the diffEditor is not configured.'));
         }
 
-        if (modelUpdate.code !== undefined) {
-            this.editorConfig.code = modelUpdate.code;
-        }
-
-        if (modelUpdate.languageId !== undefined) {
-            this.editorConfig.languageId = modelUpdate.languageId;
-        }
-
-        if (modelUpdate.uri !== undefined) {
-            this.editorConfig.uri = modelUpdate.uri;
-        }
-
-        if (modelUpdate.codeOriginal !== undefined) {
-            this.editorConfig.codeOriginal = modelUpdate.codeOriginal;
-        }
-
-        if (modelUpdate.codeOriginalUri !== undefined) {
-            this.editorConfig.codeOriginalUri = modelUpdate.codeOriginalUri;
-        }
-
+        this.updateEditorConfig(modelUpdate);
         return this.updateDiffEditorModel();
     }
 
@@ -191,6 +153,28 @@ export class MonacoEditorBase {
                 original: this.modelOriginalRef!.object!.textEditorModel,
                 modified: this.modelRef!.object!.textEditorModel
             });
+        }
+    }
+
+    private updateEditorConfig(modelUpdate: ModelUpdate) {
+        if (modelUpdate.code !== undefined) {
+            this.editorConfig.code = modelUpdate.code;
+        }
+
+        if (modelUpdate.languageId !== undefined) {
+            this.editorConfig.languageId = modelUpdate.languageId;
+        }
+
+        if (modelUpdate.uri !== undefined) {
+            this.editorConfig.uri = modelUpdate.uri;
+        }
+
+        if (modelUpdate.codeOriginal !== undefined) {
+            this.editorConfig.codeOriginal = modelUpdate.codeOriginal;
+        }
+
+        if (modelUpdate.codeOriginalUri !== undefined) {
+            this.editorConfig.codeOriginalUri = modelUpdate.codeOriginalUri;
         }
     }
 

--- a/packages/monaco-editor-wrapper/src/index.ts
+++ b/packages/monaco-editor-wrapper/src/index.ts
@@ -21,6 +21,7 @@ import type {
     WorkerConfigOptions,
     LanguageClientConfig,
     UserConfig,
+    ModelUpdate,
     MonacoEditorWrapper
 } from './wrapper.js';
 
@@ -37,7 +38,8 @@ export type {
     WebSocketConfigOptions,
     WorkerConfigOptions,
     LanguageClientConfig,
-    UserConfig
+    UserConfig,
+    ModelUpdate
 };
 
 export {

--- a/packages/monaco-editor-wrapper/src/wrapper.ts
+++ b/packages/monaco-editor-wrapper/src/wrapper.ts
@@ -37,6 +37,7 @@ export type EditorConfig = {
     theme: string;
     automaticLayout?: boolean;
     codeOriginal?: string;
+    codeOriginalUri?: string;
     editorOptions?: editor.IStandaloneEditorConstructionOptions;
     diffEditorOptions?: editor.IStandaloneDiffEditorConstructionOptions;
 }
@@ -67,6 +68,8 @@ export type ModelUpdate = {
     languageId?: string;
     code?: string;
     uri?: string;
+    codeOriginal?: string;
+    codeOriginalUri?: string;
 }
 
 export interface MonacoEditorWrapper {
@@ -200,11 +203,7 @@ export class MonacoEditorLanguageClientWrapper {
         await this.editor?.updateModel(modelUpdate);
     }
 
-    async updateDiffModel(modelUpdate: {
-        languageId: string;
-        code: string;
-        codeOriginal: string;
-    }): Promise<void> {
+    async updateDiffModel(modelUpdate: ModelUpdate): Promise<void> {
         await this.editor?.updateDiffModel(modelUpdate);
     }
 

--- a/packages/monaco-editor-wrapper/src/wrapper.ts
+++ b/packages/monaco-editor-wrapper/src/wrapper.ts
@@ -63,6 +63,12 @@ export type UserConfig = {
     languageClientConfig: LanguageClientConfig;
 }
 
+export type ModelUpdate = {
+    languageId?: string;
+    code?: string;
+    uri?: string;
+}
+
 export interface MonacoEditorWrapper {
     init(): Promise<void>;
     updateConfig(options: editor.IEditorOptions & editor.IGlobalEditorOptions | VscodeUserConfiguration): void;
@@ -190,10 +196,7 @@ export class MonacoEditorLanguageClientWrapper {
         return this.worker;
     }
 
-    async updateModel(modelUpdate: {
-        languageId: string;
-        code: string;
-    }): Promise<void> {
+    async updateModel(modelUpdate: ModelUpdate): Promise<void> {
         await this.editor?.updateModel(modelUpdate);
     }
 

--- a/packages/monaco-editor-wrapper/src/wrapper.ts
+++ b/packages/monaco-editor-wrapper/src/wrapper.ts
@@ -32,6 +32,7 @@ export type WorkerConfigOptions = {
 export type EditorConfig = {
     languageId: string;
     code: string;
+    uri?: string;
     useDiffEditor: boolean;
     theme: string;
     automaticLayout?: boolean;


### PR DESCRIPTION
Before it was not possible to use on wrapper and load different code into it because the uri for this code will always be defined by an id passed to the wrapper constructor.

With this change the uri can be set similar to the the code itself. This way the language server can differ between two file contents.

@kaisalmen Is this an appropriate change or are there other ways ?
Thanks in advance 😃 