### PR TITLE
languageClientWrapper: Reject start with unreachable web socket or web worker url

### DIFF
--- a/packages/examples/src/wrapperAdvanced.ts
+++ b/packages/examples/src/wrapperAdvanced.ts
@@ -34,6 +34,7 @@ Same again.`
     languageClientConfig: {
         options: {
             $type: 'WebSocket',
+            name: 'wrapper42 language client',
             host: 'localhost',
             port: 3000,
             path: 'sampleServer',
@@ -110,6 +111,7 @@ const sleepOne = (milliseconds: number) => {
     setTimeout(async () => {
         alert(`Updating editors after ${milliseconds}ms`);
 
+        wrapper42Config.languageClientConfig = undefined;
         const appConfig42 = wrapper42Config.wrapperConfig.editorAppConfig as EditorAppConfigClassic;
         appConfig42.languageId = 'javascript';
         appConfig42.useDiffEditor = false;
@@ -157,9 +159,13 @@ const sleepTwo = (milliseconds: number) => {
 };
 
 try {
-    await startWrapper42();
     await startWrapper43();
     await startWrapper44();
+    try {
+        await startWrapper42();
+    } catch (e) {
+        console.log(`Catched expected exception: ${e}`);
+    }
 
     // change the editors config, content or swap normal and diff editors after five seconds
     sleepOne(5000);

--- a/packages/examples/src/wrapperAdvanced.ts
+++ b/packages/examples/src/wrapperAdvanced.ts
@@ -1,4 +1,4 @@
-import { EditorAppConfigClassic, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
+import { EditorAppConfigClassic, LanguageClientError, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
 import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js';
 import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
 
@@ -164,7 +164,7 @@ try {
     try {
         await startWrapper42();
     } catch (e) {
-        console.log(`Catched expected exception: ${e}`);
+        console.log(`Catched expected connection error: ${(e as LanguageClientError).message}`);
     }
 
     // change the editors config, content or swap normal and diff editors after five seconds

--- a/packages/monaco-editor-wrapper/src/index.ts
+++ b/packages/monaco-editor-wrapper/src/index.ts
@@ -33,6 +33,7 @@ import type {
     WorkerConfigOptions,
     WorkerConfigDirect,
     LanguageClientConfig,
+    LanguageClientError
 } from './languageClientWrapper.js';
 
 import {
@@ -63,6 +64,7 @@ export type {
     WorkerConfigOptions,
     WorkerConfigDirect,
     LanguageClientConfig,
+    LanguageClientError,
     UserConfig,
     ModelUpdate
 };

--- a/packages/monaco-editor-wrapper/src/languageClientWrapper.ts
+++ b/packages/monaco-editor-wrapper/src/languageClientWrapper.ts
@@ -58,6 +58,11 @@ export type LanguageClientConfig = {
     initializationOptions?: any;
 }
 
+export type LanguageClientError = {
+    message: string;
+    error: Error | string;
+};
+
 export class LanguageClientWrapper {
 
     private languageClient: MonacoLanguageClient | undefined;
@@ -101,7 +106,11 @@ export class LanguageClientWrapper {
         if (this.languageClientConfig) {
             return this.startLanguageClientConnection();
         } else {
-            return Promise.reject('Unable to start monaco-languageclient. No configuration was provided.');
+            const languageClientError: LanguageClientError = {
+                message: `languageClientWrapper (${this.name}): Unable to start monaco-languageclient. No configuration was provided.`,
+                error: 'No error was provided.'
+            };
+            return Promise.reject(languageClientError);
         }
     }
 
@@ -122,7 +131,11 @@ export class LanguageClientWrapper {
             console.log('Re-Starting monaco-languageclient');
             await this.startLanguageClientConnection();
         } else {
-            await Promise.reject('Unable to restart languageclient. No configuration was provided.');
+            const languageClientError: LanguageClientError = {
+                message: `languageClientWrapper (${this.name}): Unable to restart languageclient. No configuration was provided.`,
+                error: 'No error was provided.'
+            };
+            await Promise.reject(languageClientError);
         }
     }
 
@@ -145,8 +158,12 @@ export class LanguageClientWrapper {
                     };
                     this.handleLanguageClientStart(messageTransports, resolve, reject);
                 };
-                webSocket.onerror = () => {
-                    reject(`languageClientWrapper (${this.name}): Websocket connection failed.`);
+                webSocket.onerror = (ev: Event) => {
+                    const languageClientError: LanguageClientError = {
+                        message: `languageClientWrapper (${this.name}): Websocket connection failed.`,
+                        error: (ev as ErrorEvent).error ?? 'No error was provided.'
+                    };
+                    reject(languageClientError);
                 };
             } else {
                 if (!this.worker) {
@@ -157,8 +174,12 @@ export class LanguageClientWrapper {
                             name: workerConfig.name
                         });
 
-                        this.worker.onerror = () => {
-                            reject(`languageClientWrapper (${this.name}): Illegal worker configuration detected. Potentially the url is wrong.`);
+                        this.worker.onerror = (ev) => {
+                            const languageClientError: LanguageClientError = {
+                                message: `languageClientWrapper (${this.name}): Illegal worker configuration detected. Potentially the url is wrong.`,
+                                error: ev.error ?? 'No error was provided.'
+                            };
+                            reject(languageClientError);
                         };
                     } else {
                         const workerDirectConfig = lcConfig as WorkerConfigDirect;
@@ -201,8 +222,11 @@ export class LanguageClientWrapper {
                 }
             }
         } catch (e) {
-            const errorMsg = `languageClientWrapper (${this.name}): Start was unsuccessful: ${e}`;
-            reject(errorMsg);
+            const languageClientError: LanguageClientError = {
+                message: `languageClientWrapper (${this.name}): Start was unsuccessful.`,
+                error: (e as Error) ?? 'No error was provided.'
+            };
+            reject(languageClientError);
         }
         resolve(`languageClientWrapper (${this.name}): Start was successfully.`);
     }
@@ -241,11 +265,19 @@ export class LanguageClientWrapper {
                 this.languageClient = undefined;
                 await Promise.resolve('monaco-languageclient and monaco-editor were successfully disposed.');
             } catch (e) {
-                await Promise.reject(`Disposing the monaco-languageclient resulted in error: ${e} `);
+                const languageClientError: LanguageClientError = {
+                    message: `languageClientWrapper (${this.name}): Disposing the monaco-languageclient resulted in error.`,
+                    error: (e as Error) ?? 'No error was provided.'
+                };
+                await Promise.reject(languageClientError);
             }
         }
         else {
-            await Promise.reject('Unable to dispose monaco-languageclient: It is not yet started.');
+            const languageClientError: LanguageClientError = {
+                message: `languageClientWrapper (${this.name}): Unable to dispose monaco-languageclient: It is not yet started.`,
+                error: 'No error was provided.'
+            };
+            await Promise.reject(languageClientError);
         }
     }
 

--- a/packages/monaco-editor-wrapper/test/languageClientWrapper.test.ts
+++ b/packages/monaco-editor-wrapper/test/languageClientWrapper.test.ts
@@ -28,4 +28,28 @@ describe('Test LanguageClientWrapper', () => {
         expect(languageClientWrapper.haveLanguageClientConfig()).toBeTruthy();
     });
 
+    test('Only bad worker url', async () => {
+        const prom = new Promise((_resolve, reject) => {
+            const worker = new Worker('aBogusUrl');
+
+            worker.onerror = () => {
+                reject('error');
+            };
+        });
+        await expect(prom).rejects.toEqual('error');
+    });
+
+    test('Start: bad worker url', async () => {
+        const languageClientConfig: LanguageClientConfig = {
+            options: {
+                $type: 'WorkerConfig',
+                url: new URL('http://localhost:63315'),
+                type: 'classic'
+            }
+        };
+        const languageClientWrapper = new LanguageClientWrapper(languageClientConfig);
+        expect(languageClientWrapper.haveLanguageClientConfig()).toBeTruthy();
+        await expect(languageClientWrapper.start()).rejects.toBe('languageClientWrapper (unnamed): Illegal worker configuration detected. Potentially the url is wrong.');
+    });
+
 });


### PR DESCRIPTION
This fixes #33. 

For both web socket and web worker in case of  `onError` the Promise is rejected with an object of type `LanguageClientError`
Tests have been enhanced. All rejections now use `LanguageClientError`, too.